### PR TITLE
Refactor: modified product pricing components and functions

### DIFF
--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -51,7 +51,7 @@ export const Navbar = () => {
 							isActive={notifsOpen}
 						/>
 					</PopoverTrigger>
-					<PopoverContent className="w-fit rounded-lg px-2 pb-2 shadow-xl">
+					<PopoverContent className="w-fit -translate-x-5 rounded-lg px-2 pb-2 shadow-xl">
 						<Notifications
 							pendingTransfers={pendingTransfers.length}
 							pendingProdPrices={pendingProductPrices.length}
@@ -59,7 +59,7 @@ export const Navbar = () => {
 					</PopoverContent>
 				</Popover>
 				{numberNotif > 0 && (
-					<span className="pointer-events-none absolute right-0 top-0 z-50 flex -translate-y-1/3 translate-x-1/3 items-center justify-center rounded-full bg-red-500 px-2 py-1 ">
+					<span className="pointer-events-none absolute right-0 top-0 flex -translate-y-1/3 translate-x-1/3 items-center justify-center rounded-full bg-red-500 px-2 py-1 ">
 						<p className="line-clamp-1 text-xs font-medium leading-tight text-white">
 							{numberNotif <= 100 ? numberNotif : '100+'}
 						</p>

--- a/client/src/features/product/__test__/components/forms/ProductPricesForm.tsx
+++ b/client/src/features/product/__test__/components/forms/ProductPricesForm.tsx
@@ -16,6 +16,13 @@ import { formatUTCDate } from '@/utils/timeUtils';
 import { Button } from '@/components';
 import { useAuth } from '@/context/AuthContext';
 import currency from 'currency.js';
+import {
+	getMarkupPercentage,
+	getMarkupValue,
+	getCostValue,
+	getPriceValue,
+} from '../../helpers/useProductPriceCalculations';
+import { toast } from 'react-toastify';
 
 interface ProductPricesFormProps {
 	onClose: UseModalProps['closeModal'];
@@ -23,89 +30,68 @@ interface ProductPricesFormProps {
 
 export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 	const { auth } = useAuth();
-	// Mutation state and handlers
+	const { selectedProductPrice } = useProductPrices();
 	const {
 		value: FormValue,
-		setValue: setFormValue,
 		handleChange,
 		handleSubmit,
 	} = useProductPricesMutation();
-	// Fetch selected product price/listing
-	const { selectedProductPrice } = useProductPrices();
+
 	// States for form submission and error message
 	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 	const [error, setError] = useState<string | null>(null);
 
-	const handleReset = () => {
-		// Omit the following properties from the selectedProductPrice object
-		const {
-			approved_by,
-			created_by,
-			created_at,
-			warehouse,
-			updated_at,
-			product,
-			id,
-			...limitedListings
-		} = selectedProductPrice;
-		setFormValue(limitedListings);
-		setMarkupPercentage(
-			currency(
-				(selectedProductPrice.markup_price /
-					selectedProductPrice.capital_price || 1) * 100, // Prevent division by zero
-				{ precision: 3 },
-			).value,
-		);
+	const [capitalPrice, setCapitalPrice] = useState<number>(
+		selectedProductPrice.capital_price,
+	);
+	const [markupPercent, setMarkupPercent] = useState<number>(
+		getMarkupPercentage(
+			selectedProductPrice.capital_price,
+			selectedProductPrice.markup_price,
+			3,
+		),
+	);
+	const [markupValue, setMarkupValue] = useState<number>(
+		selectedProductPrice.markup_price,
+	);
+
+	const handleCapitalPriceChange = (
+		e: React.ChangeEvent<HTMLInputElement>,
+	) => {
+		const value = e.target.value;
+		setCapitalPrice(currency(value).value);
+		handleChange('capital_price', currency(value).value);
+		setMarkupValue(getMarkupValue(currency(value).value, markupPercent || 0));
 	};
 
-	// MARKUP PERCENT & PRICE
-	// markupPercentage = (markup_price / capital_price) * 100
-	// markup_price = capital_price * (markupPercentage / 100)
-	const [markupPercentage, setMarkupPercentage] = useState<number>(
-		currency(
-			(selectedProductPrice.markup_price /
-				selectedProductPrice.capital_price || 1) * 100, // Prevent division by zero
-			{ precision: 3 },
-		).value,
-	);
+	const handleMarkupPercentChange = (
+		e: React.ChangeEvent<HTMLInputElement>,
+	) => {
+		const value = Number(e.target.value);
+		setMarkupPercent(value);
+		setMarkupValue(getMarkupValue(capitalPrice, value));
+	};
+
+	const handleMarkupValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const value = currency(e.target.value).value;
+		setMarkupValue(value);
+		setMarkupPercent(getMarkupPercentage(capitalPrice, value, 3));
+	};
+
 	useEffect(() => {
-		const capitalPrice =
-			FormValue.capital_price !== undefined
-				? FormValue.capital_price
-				: selectedProductPrice.capital_price || 0;
-		const markup = currency(capitalPrice).multiply(markupPercentage / 100);
+		handleChange('capital_price', capitalPrice);
+		handleChange('markup_price', markupValue);
+		handleChange('cost', getCostValue(capitalPrice, markupValue));
+	}, [capitalPrice, markupPercent, markupValue]);
 
-		handleChange('markup_price', markup.value);
-	}, [FormValue.capital_price, markupPercentage]);
-
-	// COST VALUE CALCULATION
-	// cost = capital_price + markup_price
 	useEffect(() => {
-		const capitalPrice =
-			FormValue.capital_price !== undefined
-				? FormValue.capital_price
-				: selectedProductPrice.capital_price;
-		const markupPrice =
-			FormValue.markup_price !== undefined
-				? FormValue.markup_price
-				: selectedProductPrice.markup_price;
-
-		handleChange('cost', currency(capitalPrice).add(markupPrice).value);
-	}, [FormValue.capital_price, FormValue.markup_price]);
-
-	// PRICE CALCULATION
-	// price = cost - sale_discount
-	useEffect(() => {
-		const cost =
-			FormValue.cost !== undefined
-				? FormValue.cost
-				: selectedProductPrice.cost;
-		const saleDiscount =
-			FormValue.sale_discount !== undefined
-				? FormValue.sale_discount
-				: selectedProductPrice.sale_discount;
-
-		handleChange('price', currency(cost).subtract(saleDiscount).value);
+		handleChange(
+			'price',
+			getPriceValue(
+				FormValue.cost ?? selectedProductPrice.cost,
+				FormValue.sale_discount ?? selectedProductPrice.sale_discount,
+			),
+		);
 	}, [FormValue.cost, FormValue.sale_discount]);
 
 	return (
@@ -114,69 +100,76 @@ export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 				onSubmit={async e => {
 					setIsSubmitting(!isSubmitting);
 					e.preventDefault();
-					const response = await handleSubmit({
+					handleSubmit({
 						action: 'update',
 						id: selectedProductPrice.id,
 						data: FormValue,
-					});
-					response?.status === 200 // 200 means request success
-						? (setIsSubmitting(!isSubmitting), onClose())
-						: (setIsSubmitting(!isSubmitting),
-							setError('Failed to update product listing'));
+					})
+						.then(() => {
+							setIsSubmitting(!isSubmitting);
+							toast.success('Product price edited successfully');
+							onClose();
+						})
+						.catch(() => {
+							setIsSubmitting(!isSubmitting);
+							setError('Failed to add product listing');
+							toast.error('Failed to add product listing');
+						});
 				}}
 			>
 				<div className="flex max-w-2xl flex-col gap-3">
-					<div className="mt-3 grid w-full grid-flow-row grid-cols-12 gap-x-3 gap-y-5">
-						<div className="col-span-3 flex flex-col justify-center gap-1">
+					<div className="mt-3 grid w-full grid-flow-row grid-cols-12 gap-x-3 gap-y-5 font-medium text-gray-700">
+						<div className="col-span-4 flex flex-col justify-center gap-1">
 							<h3 className="text-sm font-bold text-gray-600">Name</h3>
 							<p className="text-sm">
 								{selectedProductPrice.product.name}
 							</p>
 						</div>
-						<div className="col-span-3 flex flex-col justify-center gap-1">
+						<div className="col-span-4 flex flex-col justify-center gap-1">
+							<h3 className="text-sm font-bold text-gray-600">Brand</h3>
+							<p className="text-sm">
+								{selectedProductPrice.product.brand || (
+									<span className="opacity-60">No brand</span>
+								)}
+							</p>
+						</div>
+						<div className="col-span-4 flex flex-col justify-center gap-1">
+							<h3 className="text-sm font-bold text-gray-600">
+								Serial Number
+							</h3>
+							<p className="text-sm">
+								{selectedProductPrice.product.serial_no}
+							</p>
+						</div>
+						<div className="col-span-4 flex flex-col justify-center gap-1">
+							<Label
+								htmlFor="unit"
+								className="text-sm font-bold text-gray-600"
+							>
+								Unit
+							</Label>
+							<Input
+								id="unit"
+								name="unit"
+								type="text"
+								maxLength={20}
+								required
+								value={FormValue.unit || selectedProductPrice.unit}
+								onChange={e => {
+									handleChange('unit', e.target.value);
+								}}
+							/>
+						</div>
+						<div className="col-span-4 flex flex-col justify-center gap-1">
 							<h3 className="text-sm font-bold text-gray-600">Size</h3>
 							<p className="text-sm">
 								{selectedProductPrice.product.size}
 							</p>
 						</div>
-						<div className="col-span-3 flex flex-col justify-center gap-1">
+						<div className="col-span-4 flex flex-col justify-center gap-1">
 							<h3 className="text-sm font-bold text-gray-600">Color</h3>
 							<p className="text-sm">
 								{selectedProductPrice.product.color}
-							</p>
-						</div>
-						<div className="col-span-3 flex flex-col justify-center	gap-1">
-							<h3 className="text-sm font-bold text-gray-600">
-								Warehouse
-							</h3>
-							<p className="text-sm">
-								{selectedProductPrice.warehouse.code}
-							</p>
-						</div>
-						<div className="col-span-3 flex flex-col justify-center	gap-1">
-							<h3 className="text-sm font-bold text-gray-600">Type</h3>
-							<p className="text-sm capitalize">
-								{selectedProductPrice.type}
-							</p>
-						</div>
-						<div className="col-span-3 flex flex-col justify-center	gap-1">
-							<h3 className="text-sm font-bold text-gray-600">Unit</h3>
-							<p className="text-sm">{selectedProductPrice.unit}</p>
-						</div>
-						<div className="col-span-3 flex flex-col justify-center	gap-1">
-							<h3 className="text-sm font-bold text-gray-600">
-								Stocks quantity
-							</h3>
-							<p className="text-sm">
-								{selectedProductPrice.stocks_quantity}
-							</p>
-						</div>
-						<div className="col-span-3 flex flex-col justify-center	gap-1">
-							<h3 className="text-sm font-bold text-gray-600">
-								Stocks unit
-							</h3>
-							<p className="text-sm">
-								{selectedProductPrice.stocks_unit}
 							</p>
 						</div>
 					</div>
@@ -197,25 +190,11 @@ export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 								min={0}
 								step={0.01}
 								required
-								placeholder={'0.00'}
 								className="pl-7"
-								value={
-									FormValue.capital_price ||
-									selectedProductPrice.capital_price.toFixed(2)
-								}
-								onChange={e => {
-									handleChange(
-										'capital_price',
-										currency(e.target.value).value,
-									);
-								}}
+								value={capitalPrice || ''}
+								onChange={handleCapitalPriceChange}
 								onBlur={e => {
-									FormValue.capital_price !== undefined
-										? (e.target.value = Number(
-												FormValue.capital_price,
-											).toFixed(2))
-										: selectedProductPrice.capital_price.toFixed(2) ||
-											'0.00';
+									e.target.value = Number(capitalPrice).toFixed(2);
 								}}
 							/>
 							<span className="absolute bottom-0 left-0 ml-3 -translate-y-1/2 text-sm font-semibold text-gray-500">
@@ -238,15 +217,12 @@ export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 								max={1000}
 								step={0.001}
 								required
-								placeholder={'0'}
-								value={markupPercentage.toString()}
-								onChange={e => {
-									setMarkupPercentage(
-										currency(e.target.value, { precision: 3 }).value,
-									);
-								}}
+								value={markupPercent || ''}
+								onChange={handleMarkupPercentChange}
 								onBlur={e => {
-									e.target.value = markupPercentage.toString();
+									e.target.value = currency(markupPercent, {
+										precision: 3,
+									}).value.toString();
 								}}
 							/>
 							<span className="absolute bottom-0 right-0 mr-2 -translate-y-1/2 text-sm font-semibold text-gray-500">
@@ -266,14 +242,13 @@ export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 								type="number"
 								min={0}
 								max={1000}
-								readOnly
-								placeholder={'0'}
+								step={0.01}
 								className="pl-7"
-								value={
-									FormValue.markup_price?.toFixed(2) ||
-									selectedProductPrice.markup_price.toFixed(2) ||
-									'0.00'
-								}
+								value={markupValue || ''}
+								onChange={handleMarkupValueChange}
+								onBlur={e => {
+									e.target.value = Number(markupValue).toFixed(2);
+								}}
 							/>
 							<span className="absolute bottom-0 left-0 ml-3 -translate-y-1/2 text-sm font-semibold text-gray-500">
 								₱
@@ -295,8 +270,7 @@ export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 								className="pl-7"
 								readOnly
 								value={
-									FormValue.cost?.toFixed(2) ||
-									selectedProductPrice.cost.toFixed(2) ||
+									getCostValue(capitalPrice, markupValue).toFixed(2) ||
 									'0.00'
 								}
 							/>
@@ -329,12 +303,11 @@ export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 										: FormValue.on_sale === 0
 								}
 								required
-								placeholder="0.00"
 								className="pl-7"
 								value={
-									FormValue.sale_discount ||
-									selectedProductPrice.sale_discount?.toFixed(2) ||
-									'0.00'
+									FormValue.sale_discount ??
+									selectedProductPrice.sale_discount?.toFixed(2) ??
+									''
 								}
 								onChange={e => {
 									handleChange(
@@ -533,25 +506,12 @@ export const ProductPricesForm = ({ onClose }: ProductPricesFormProps) => {
 							</p>
 						</div>
 					</div>
-					<div className="flex w-full flex-row justify-between pt-4">
-						<div className="flex flex-row">
+					<div className="col-span-12 flex w-full justify-between whitespace-nowrap pt-4">
+						<div className="ml-auto flex flex-row gap-4">
 							<Button
 								type="reset"
 								fill={'default'}
-								disabled={
-									isSubmitting || Object.keys(FormValue).length === 0
-								}
-								className="flex-1 py-2 text-sm font-bold text-gray-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
-								onClick={handleReset}
-							>
-								Reset
-							</Button>
-						</div>
-						<div className="flex flex-row gap-4 whitespace-nowrap">
-							<Button
-								type="reset"
-								fill={'default'}
-								className="flex-1 py-2 text-sm font-bold text-gray-700 hover:text-white"
+								className="flex-1 py-2 text-sm font-bold text-slate-700 hover:text-white"
 								onClick={onClose}
 							>
 								Cancel

--- a/client/src/features/product/__test__/components/modal/AddProdPrice.tsx
+++ b/client/src/features/product/__test__/components/modal/AddProdPrice.tsx
@@ -1,15 +1,11 @@
 import { UseModalProps } from '@/utils/Modal';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { AddProdPriceProdsTab } from '../forms/AddProdPriceProdsTab';
 import { AddProdPriceListingsTab } from '../forms/AddProdPriceListingsTab';
 import { useWarehouseQuery } from '@/features/warehouse/__test__/hooks';
-import { Inventory, InventoryProduct } from '@/features/inventory/types';
-import {
-	fetchInventoryByWarehouseId,
-	fetchInventoryProductById,
-} from '@/features/inventory/api/Inventory';
 import { Warehouse } from '@/features/warehouse/__test__/types';
+import { useProducts } from '../../context/ProductContext';
 
 interface AddProductPriceProps {
 	onClose: UseModalProps['closeModal'];
@@ -20,34 +16,8 @@ export const AddProductPrice = ({ onClose }: AddProductPriceProps) => {
 	const { warehouses } = useWarehouseQuery();
 	const [selectedWarehouse, setSelectedWarehouse] = useState<Warehouse>();
 
-	// INVENTORIES - State and query
-	// Dependent on selectedWarehouse
-	const [inventories, setInventories] = useState<Inventory[]>([]);
-	const [selectedInventory, setSelectedInventory] = useState<Inventory>();
-	useEffect(() => {
-		setInventories([]);
-		if (selectedWarehouse) {
-			fetchInventoryByWarehouseId(selectedWarehouse.id).then(data => {
-				setInventories(data);
-			});
-		}
-	}, [selectedWarehouse]);
-
-	// INVENTORY PRODUCTS - State and query
-	// Dependent on selectedInventory
-	const [inventoryProducts, setInventoryProducts] = useState<
-		InventoryProduct[]
-	>([]);
-	const [selectedInventoryProduct, setSelectedInventoryProduct] =
-		useState<InventoryProduct>();
-	useEffect(() => {
-		setInventoryProducts([]);
-		if (selectedInventory) {
-			fetchInventoryProductById(selectedInventory.id).then(data => {
-				setInventoryProducts(data);
-			});
-		}
-	}, [selectedInventory]);
+	// PRODUCTS
+	const { selectedProduct } = useProducts();
 
 	// TABS
 	const [openedTab, setOpenedTab] = useState('product');
@@ -68,7 +38,7 @@ export const AddProductPrice = ({ onClose }: AddProductPriceProps) => {
 						Product
 					</TabsTrigger>
 					<TabsTrigger
-						disabled={selectedInventoryProduct ? false : true}
+						disabled={!selectedProduct}
 						value="listings"
 						className="rounded-md py-1 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
 					>
@@ -76,28 +46,20 @@ export const AddProductPrice = ({ onClose }: AddProductPriceProps) => {
 					</TabsTrigger>
 				</TabsList>
 				<TabsContent value="product">
-					{/* Inventory products tab content */}
+					{/* Products tab content */}
 					<AddProdPriceProdsTab
 						warehouses={warehouses}
 						selectedWarehouse={selectedWarehouse}
 						setSelectedWarehouse={setSelectedWarehouse}
-						inventories={inventories}
-						selectedInventory={selectedInventory}
-						setSelectedInventory={setSelectedInventory}
-						inventoryProducts={inventoryProducts}
-						selectedInventoryProduct={selectedInventoryProduct}
-						setSelectedInventoryProduct={setSelectedInventoryProduct}
 						setOpenedTab={setOpenedTab}
 						onClose={onClose}
 					/>
 				</TabsContent>
 				<TabsContent value="listings">
-					{/* Listing tab content */}
-					{selectedInventoryProduct && (
+					{/* Listing/pricing tab content */}
+					{selectedProduct && (
 						<AddProdPriceListingsTab
 							selectedWarehouse={selectedWarehouse || ({} as Warehouse)}
-							selectedInventory={selectedInventory || ({} as Inventory)}
-							selectedInventoryProduct={selectedInventoryProduct}
 							setOpenedTab={setOpenedTab}
 							onClose={onClose}
 						/>

--- a/client/src/features/product/__test__/components/table/ProductPricesTable.tsx
+++ b/client/src/features/product/__test__/components/table/ProductPricesTable.tsx
@@ -1,8 +1,8 @@
 import { DataTable } from '@/components/Tables/DataTable';
 import { useProductPrices } from '../..';
 import { Product, ProductPrices } from '../../types';
-import { useAuth } from '@/context/AuthContext';
-import { ProductPricesColumns, ProductPricesColumnsLimited } from '.';
+import { ProductPricesColumns } from '.';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 interface ProductsPricesTableProps {
 	openModal: (data: ProductPrices | Product, action: string) => void;
@@ -15,7 +15,6 @@ export const ProductPricesTable = ({
 	isModalOpen,
 	filterWarehouse,
 }: ProductsPricesTableProps) => {
-	const { auth } = useAuth();
 	const { data, isLoading, setSelectedProductPrice } = useProductPrices();
 
 	const handleAddProdPrice = () => {
@@ -42,28 +41,26 @@ export const ProductPricesTable = ({
 
 	return (
 		<>
-			<DataTable
-				columns={
-					// If user is a super admin or admin, show all columns
-					// else, show only limited columns
-					auth.role === 'super_admin' || auth.role === 'admin'
-						? ProductPricesColumns({
-								handleProdPriceDetails,
-								handleEditProdPrice,
-								handleToggleActiveStatus,
-							})
-						: ProductPricesColumnsLimited
-				}
-				data={
-					filterWarehouse
-						? data.filter(item => item.warehouse.id === filterWarehouse)
-						: data
-				}
-				filterWhat={'name'}
-				dataType={'Listing'}
-				openModal={handleAddProdPrice}
-				isLoading={isLoading}
-			/>
+			<TooltipProvider>
+				<DataTable
+					columns={ProductPricesColumns({
+						handleProdPriceDetails,
+						handleEditProdPrice,
+						handleToggleActiveStatus,
+					})}
+					data={
+						filterWarehouse
+							? data.filter(
+									item => item.warehouse.id === filterWarehouse,
+								)
+							: data
+					}
+					filterWhat={'name'}
+					dataType={'Listing'}
+					openModal={handleAddProdPrice}
+					isLoading={isLoading}
+				/>
+			</TooltipProvider>
 		</>
 	);
 };

--- a/client/src/features/product/__test__/components/table/columns/ProductPricesCols.tsx
+++ b/client/src/features/product/__test__/components/table/columns/ProductPricesCols.tsx
@@ -26,6 +26,11 @@ import {
 	ArrowUpDown,
 } from 'lucide-react';
 import currency from 'currency.js';
+import {
+	Tooltip,
+	TooltipTrigger,
+	TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface ProductPricesColumnsProps {
 	handleProdPriceDetails: (productPrice: ProductPrices) => void;
@@ -101,34 +106,7 @@ export const ProductPricesColumns = ({
 			header: () => <div className="justify-center uppercase">WHS</div>,
 		},
 		{
-			accessorKey: 'type',
-			header: () => <div className="justify-center uppercase">Type</div>,
-			cell: ({ row }) => {
-				const type = row.original.type;
-				return (
-					<div className="group relative flex w-fit items-center">
-						{type === 'retail' ? (
-							<Box size={20} strokeWidth={2} className="text-gray-700" />
-						) : (
-							<Boxes
-								size={20}
-								strokeWidth={1.75}
-								className="text-gray-700"
-							/>
-						)}
-						<span className="text-nowrap absolute left-1/2 mx-auto -translate-x-1/2 -translate-y-7 rounded-md bg-gray-800 px-1 text-sm capitalize text-gray-100 opacity-0 transition-opacity group-hover:opacity-100">
-							{type}
-						</span>
-					</div>
-				);
-			},
-		},
-		{
-			accessorKey: 'stocks_quantity',
-			header: () => <div className="justify-center uppercase">QTY</div>,
-		},
-		{
-			accessorKey: 'stocks_unit',
+			accessorKey: 'unit',
 			header: () => <div className="justify-center uppercase">Unit</div>,
 		},
 		{
@@ -179,18 +157,24 @@ export const ProductPricesColumns = ({
 				return (
 					<div className="flex items-center">
 						<span>
-							{row.original.on_sale === 1 ? (
+							{!!row.original.on_sale ? (
 								formatted
 							) : (
 								<div className="group relative flex w-fit items-center">
-									<X
-										size={20}
-										strokeWidth={2}
-										className="text-gray-700"
-									/>
-									<span className="text-nowrap absolute left-1/2 mx-auto -translate-x-1/2 -translate-y-7 rounded-md bg-gray-800 px-1 text-sm normal-case text-gray-100 opacity-0 transition-opacity group-hover:opacity-100">
-										Not on sale
-									</span>
+									<Tooltip>
+										<TooltipTrigger>
+											<X
+												size={20}
+												strokeWidth={2}
+												className="text-gray-700"
+											/>
+										</TooltipTrigger>
+										<TooltipContent>
+											<p className="text-sm font-medium normal-case">
+												Not on sale
+											</p>
+										</TooltipContent>
+									</Tooltip>
 								</div>
 							)}
 						</span>
@@ -216,36 +200,62 @@ export const ProductPricesColumns = ({
 
 		{
 			accessorKey: 'approval_status',
-			header: () => (
-				<div className="mx-auto w-fit text-center uppercase">Approval</div>
-			),
+			sortingFn: 'basic',
+			enableSorting: true,
+			header: ({ column }) => {
+				return (
+					<div>
+						<Button
+							onClick={() =>
+								column.toggleSorting(column.getIsSorted() === 'asc')
+							}
+							className="ml-auto mr-auto flex flex-row items-center bg-transparent uppercase text-slate-700"
+						>
+							Approval{' '}
+							{column.getIsSorted() === 'asc' ? (
+								<ArrowUp size={18} strokeWidth={2} />
+							) : column.getIsSorted() === 'desc' ? (
+								<ArrowDown size={18} strokeWidth={2} />
+							) : (
+								<ArrowUpDown size={18} strokeWidth={2} />
+							)}
+						</Button>
+					</div>
+				);
+			},
 			cell: ({ row }) => {
 				const status = row.original.approval_status;
 				return (
 					<>
 						<div className="group relative mx-auto flex w-fit items-center justify-center">
-							{status === 'approved' ? (
-								<Check
-									size={20}
-									strokeWidth={2}
-									className="text-green-600"
-								/>
-							) : status === 'rejected' ? (
-								<Ban
-									size={20}
-									strokeWidth={2}
-									className="text-red-600"
-								/>
-							) : (
-								<Clock
-									size={20}
-									strokeWidth={2}
-									className="text-amber-500"
-								/>
-							)}
-							<span className="absolute left-1/2 mx-auto -translate-x-1/2 -translate-y-7 rounded-md bg-gray-800 px-1 text-sm capitalize text-gray-100 opacity-0 transition-opacity group-hover:opacity-100">
-								{status}
-							</span>
+							<Tooltip>
+								<TooltipTrigger>
+									{status === 'approved' ? (
+										<Check
+											size={20}
+											strokeWidth={2}
+											className="text-green-600"
+										/>
+									) : status === 'rejected' ? (
+										<Ban
+											size={20}
+											strokeWidth={2}
+											className="text-red-600"
+										/>
+									) : (
+										<Clock
+											size={20}
+											strokeWidth={2}
+											className="text-amber-500"
+										/>
+									)}
+								</TooltipTrigger>
+								<TooltipContent>
+									<p className="text-sm font-medium capitalize">
+										{status}
+									</p>
+								</TooltipContent>
+							</Tooltip>
 						</div>
 					</>
 				);
@@ -280,22 +290,28 @@ export const ProductPricesColumns = ({
 				const active = row.original.active_status;
 				return (
 					<div className="group relative mx-auto flex w-fit items-center justify-center">
-						{active === 'active' ? (
-							<Check
-								size={20}
-								strokeWidth={2}
-								className="text-green-600"
-							/>
-						) : (
-							<CircleOff
-								size={20}
-								strokeWidth={2}
-								className="text-gray-600"
-							/>
-						)}
-						<span className="text-nowrap absolute left-1/2 mx-auto -translate-x-1/2 -translate-y-7 rounded-md bg-gray-800 px-1 text-sm normal-case text-gray-100 opacity-0 transition-opacity group-hover:opacity-100">
-							{active === 'active' ? 'Active' : 'Inactive'}
-						</span>
+						<Tooltip>
+							<TooltipTrigger>
+								{active === 'active' ? (
+									<Check
+										size={20}
+										strokeWidth={2}
+										className="text-green-600"
+									/>
+								) : (
+									<CircleOff
+										size={20}
+										strokeWidth={2}
+										className="text-gray-600"
+									/>
+								)}
+							</TooltipTrigger>
+							<TooltipContent>
+								<p className="text-sm font-medium capitalize">
+									{active}
+								</p>
+							</TooltipContent>
+						</Tooltip>
 					</div>
 				);
 			},

--- a/client/src/features/product/__test__/context/ProductContext.tsx
+++ b/client/src/features/product/__test__/context/ProductContext.tsx
@@ -5,8 +5,10 @@ import { useProductQuery } from '../hooks';
 interface ProductContextProps {
 	data: Product[];
 	isLoading: boolean;
-	selectedProduct: Product;
-	setSelectedProduct: (product: Product) => void;
+	selectedProduct: Product | undefined;
+	setSelectedProduct: React.Dispatch<
+		React.SetStateAction<Product | undefined>
+	>;
 }
 interface ProductProviderProps {
 	children: ReactNode;
@@ -17,9 +19,9 @@ const ProductContext = createContext<ProductContextProps | undefined>(
 
 export const ProductsProvider = ({ children }: ProductProviderProps) => {
 	// State of the selected product
-	const [selectedProduct, setSelectedProduct] = useState<Product>(
-		{} as Product,
-	);
+	const [selectedProduct, setSelectedProduct] = useState<
+		Product | undefined
+	>();
 	// Destructured response data and loading state from useProductQuery hook
 	const { data, isLoading } = useProductQuery();
 	const value = {

--- a/client/src/features/product/__test__/helpers/useProductPriceCalculations.ts
+++ b/client/src/features/product/__test__/helpers/useProductPriceCalculations.ts
@@ -1,0 +1,73 @@
+import currency from 'currency.js';
+
+/**
+ * Calculates the markup percentage based on the given value and markup value.
+ *
+ * @param value - The original value.
+ * @param markupValue - The markup value.
+ * @param precision - The decimal places of the calculated percentage (default: 2).
+ * @returns The markup percentage.
+ */
+const getMarkupPercentage = (
+	value: number,
+	markupValue: number,
+	precision: number = 2,
+) => {
+	return currency((markupValue / value) * 100, {
+		precision: precision,
+	}).value;
+};
+
+/**
+ * Calculates the markup value based on the given value and markup percentage.
+ * @param value - The original value.
+ * @param markupPercent - The markup percentage.
+ * @param precision - The decimal places of the calculated value (default: 2).
+ * @returns The calculated markup value.
+ */
+const getMarkupValue = (
+	value: number,
+	markupPercent: number,
+	precision: number = 2,
+) => {
+	return currency(currency(value).multiply(markupPercent / 100), {
+		precision: precision,
+	}).value;
+};
+
+/**
+ * Calculates the cost value by adding two values and returning the result.
+ *
+ * @param value1 - The first value to be added.
+ * @param value2 - The second value to be added.
+ * @param precision - The decimal places of the calculated value (default: 2).
+ * @returns The cost value calculated by adding `value1` and `value2`.
+ */
+const getCostValue = (
+	value1: number,
+	value2: number,
+	precision: number = 2,
+) => {
+	return currency(currency(value1).add(value2), {
+		precision: precision,
+	}).value;
+};
+
+/**
+ * Calculates the price value by subtracting value2 from value1.
+ *
+ * @param value1 - The first value.
+ * @param value2 - The second value.
+ * @param precision - The decimal places of the calculated value (default: 2).
+ * @returns The calculated price value.
+ */
+const getPriceValue = (
+	value1: number,
+	value2: number,
+	precision: number = 2,
+) => {
+	return currency(currency(value1).subtract(value2), { precision: precision })
+		.value;
+};
+
+export { getMarkupPercentage, getMarkupValue, getCostValue, getPriceValue };

--- a/client/src/features/product/__test__/types/index.ts
+++ b/client/src/features/product/__test__/types/index.ts
@@ -4,7 +4,7 @@ export interface Product {
 	id: number;
 	name: string;
 	serial_no: string;
-	brand?: string;
+	brand: string;
 	size: string;
 	color: string;
 	notes: string;
@@ -20,11 +20,8 @@ export interface ProductPrices {
 	product: Partial<Product>;
 	type: 'retail' | 'wholesale' | string;
 	unit: string;
-	stocks_quantity: number;
-	stocks_unit: string;
 	capital_price: number;
 	markup_price: number;
-	tax_amount: number; // remove when removed from database, its currently NOT NULL
 	cost: number;
 	on_sale: number;
 	sale_discount: number;

--- a/client/src/pages/__test__/ProductPricesPage.tsx
+++ b/client/src/pages/__test__/ProductPricesPage.tsx
@@ -22,6 +22,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { useWarehouseQuery } from '@/features/warehouse/__test__/hooks';
+import { ProductsProvider } from '@/features/product/__test__/context/ProductContext';
 
 export const ProductPrices = () => {
 	const { warehouses } = useWarehouseQuery();
@@ -41,84 +42,86 @@ export const ProductPrices = () => {
 	return (
 		<>
 			<MainLayout title="Product Listings">
-				<ProductPricesProvider>
-					<div className="flex max-h-full flex-1 flex-col gap-5 rounded-lg border border-black/10 bg-white p-5">
-						<div className="ml-auto flex flex-row items-center space-x-4">
-							<span className="text-sm font-medium">
-								Filter warehouse:{' '}
-							</span>
-							{/* //* Warehouse id of zero is assumed 'all' */}
-							<Select
-								defaultValue="0"
-								onValueChange={value =>
-									setFilterWarehouse(Number(value))
-								}
-							>
-								<SelectTrigger className="w-[300px] text-sm font-medium">
-									<SelectValue placeholder="All" />
-								</SelectTrigger>
-								<SelectContent className="text-sm font-medium capitalize">
-									<SelectItem key="all" value="0">
-										All
-									</SelectItem>
-									{warehouses.map(warehouse => (
-										<SelectItem
-											key={warehouse.id}
-											value={warehouse.id.toString()}
-										>
-											{warehouse.name} ({warehouse.code})
+				<ProductsProvider>
+					<ProductPricesProvider>
+						<div className="flex max-h-full flex-1 flex-col gap-5 rounded-lg border border-black/10 bg-white p-5">
+							<div className="ml-auto flex flex-row items-center space-x-4">
+								<span className="text-sm font-medium">
+									Filter warehouse:{' '}
+								</span>
+								{/* //* Warehouse id of zero is assumed 'all' */}
+								<Select
+									defaultValue="0"
+									onValueChange={value =>
+										setFilterWarehouse(Number(value))
+									}
+								>
+									<SelectTrigger className="w-[300px] text-sm font-medium">
+										<SelectValue placeholder="All" />
+									</SelectTrigger>
+									<SelectContent className="text-sm font-medium capitalize">
+										<SelectItem key="all" value="0">
+											All
 										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+										{warehouses.map(warehouse => (
+											<SelectItem
+												key={warehouse.id}
+												value={warehouse.id.toString()}
+											>
+												{warehouse.name} ({warehouse.code})
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="w-full overflow-x-hidden rounded-lg border border-black/10">
+								<ProductPricesTable
+									openModal={modalHandler}
+									isModalOpen={isOpen}
+									filterWarehouse={
+										// If filterWarehouse is given (greater than 0),
+										// filter the inventory data by warehouse code
+										filterWarehouse > 0 ? filterWarehouse : undefined
+									}
+								/>
+							</div>
 						</div>
-						<div className="w-full overflow-x-hidden rounded-lg border border-black/10">
-							<ProductPricesTable
-								openModal={modalHandler}
-								isModalOpen={isOpen}
-								filterWarehouse={
-									// If filterWarehouse is given (greater than 0),
-									// filter the inventory data by warehouse code
-									filterWarehouse > 0 ? filterWarehouse : undefined
-								}
-							/>
-						</div>
-					</div>
-					<ModalTest
-						title={
-							modalAction === 'add'
-								? 'Add Listing'
-								: modalAction === 'details'
-									? 'Listing Details'
-									: modalAction === 'edit'
-										? 'Edit Listing'
-										: modalAction === 'toggle_active_stat'
-											? 'Toggle Active Status'
-											: ''
-						}
-						isOpen={isOpen}
-						onClose={closeModal}
-						closeOnOverlayClick={
-							modalAction === 'details' ||
-							modalAction === 'toggle_active_stat'
-						}
-					>
-						<>
-							{modalAction === 'add' && (
-								<AddProductPrice onClose={closeModal} />
-							)}
-							{modalAction === 'details' && (
-								<ProdPriceDetails onClose={closeModal} />
-							)}
-							{modalAction === 'edit' && (
-								<ProductPricesForm onClose={closeModal} />
-							)}
-							{modalAction === 'toggle_active_stat' && (
-								<ProdPriceActiveToggle onClose={closeModal} />
-							)}
-						</>
-					</ModalTest>
-				</ProductPricesProvider>
+						<ModalTest
+							title={
+								modalAction === 'add'
+									? 'Add Listing'
+									: modalAction === 'details'
+										? 'Listing Details'
+										: modalAction === 'edit'
+											? 'Edit Listing'
+											: modalAction === 'toggle_active_stat'
+												? 'Toggle Active Status'
+												: ''
+							}
+							isOpen={isOpen}
+							onClose={closeModal}
+							closeOnOverlayClick={
+								modalAction === 'details' ||
+								modalAction === 'toggle_active_stat'
+							}
+						>
+							<>
+								{modalAction === 'add' && (
+									<AddProductPrice onClose={closeModal} />
+								)}
+								{modalAction === 'details' && (
+									<ProdPriceDetails onClose={closeModal} />
+								)}
+								{modalAction === 'edit' && (
+									<ProductPricesForm onClose={closeModal} />
+								)}
+								{modalAction === 'toggle_active_stat' && (
+									<ProdPriceActiveToggle onClose={closeModal} />
+								)}
+							</>
+						</ModalTest>
+					</ProductPricesProvider>
+				</ProductsProvider>
 			</MainLayout>
 		</>
 	);


### PR DESCRIPTION
- allowed input in both markup percent and markup price in  product pricing forms
- separated pricing calculation functions
- modified product prices to only allow adding a product price/listing to a warehouse ONCE
- product pricing `unit` is set to `pcs` as default
- toastified product pricing submit functions
- added tooltips to icons in the table
- removed `stocks_quantity`, `stocks_unit`, `tax_amount` from productprices type
- removed removed properties in product_prices table columns